### PR TITLE
Add direct link to request data archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please note that it does **not** search their posts, however - for that, it is r
 
 **Prerequisites**: This uses the latest version of Node.js to run. [You'll need to install that.](https://nodejs.org/en/download/)
 
-First, request your data archive from the bird site. This can be done by going to Settings > Account > Download an archive of your data. It can take 24 hours or more for this file to be generated.
+First, request your data archive from the bird site. This can be done by going to Settings > Account > Download an archive of your data, or by going directly to https://twitter.com/settings/download_your_data. It can take 24 hours or more for this file to be generated.
 
 Next, download a copy of this repo, and expand it. Use node to install the dependencies. Typically you'll just need to run `npm install` in the directory of this script.
 


### PR DESCRIPTION
I added the direct link since it took me a few moments to find the path suggested. I tested this against an alt account and navigating directly there, even when not logged in, works (after the auth flow).